### PR TITLE
Adds elapsedTime and statusCode to RequestStream output

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,12 +98,13 @@ function RequestStream(options) {
             request({
                 agent: options.agent,
                 encoding: null,
-                uri: requrl
+                uri: requrl,
+                time: true
             }, function(err, res, body) {
                 requestStream.pending--;
                 if (err) return requestStream.emit('error', err);
                 if (res.statusCode !== 200) return next();
-                requestStream.push({ url: requrl, body: body });
+                requestStream.push({ url: requrl, elapsedTime: res.elapsedTime, body: body });
                 requestStream.got++;
                 next();
             });

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function RequestStream(options) {
                 requestStream.pending--;
                 if (err) return requestStream.emit('error', err);
                 if (res.statusCode !== 200) return next();
-                requestStream.push({ url: requrl, elapsedTime: res.elapsedTime, body: body });
+                requestStream.push({ url: requrl, elapsedTime: res.elapsedTime, statusCode: res.statusCode, body: body });
                 requestStream.got++;
                 next();
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log-replay",
-  "version": "2.2.3-0",
+  "version": "2.2.3-1",
   "description": "Transform and replay CloudFront, ELB Classic, and ALB logs.",
   "main": "index.js",
   "author": "Mapbox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log-replay",
-  "version": "2.2.2",
+  "version": "2.2.3-0",
   "description": "Transform and replay CloudFront, ELB Classic, and ALB logs.",
   "main": "index.js",
   "author": "Mapbox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log-replay",
-  "version": "2.3.0",
+  "version": "2.3.1-0",
   "description": "Transform and replay CloudFront, ELB Classic, and ALB logs.",
   "main": "index.js",
   "author": "Mapbox",

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -26,9 +26,9 @@ tape('RequestStream [concurrency]', function(assert) {
         baseurl: 'http://localhost:9999',
         hwm: 3
     });
-    reqstream.on('data', function(d) { 
+    reqstream.on('data', function(d) {
     });
-    reqstream.on('end', function() { 
+    reqstream.on('end', function() {
         assert.end();
     });
     var req = 0;
@@ -52,6 +52,7 @@ tape('RequestStream', function(assert) {
     });
     reqstream.on('data', function(d) {
         assert.deepEqual(/http:\/\/localhost:9999\/(a|b)\.json/.test(d.url), true, 'data.url is object url');
+        assert.deepEqual(isNaN(d.elapsedTime), false, 'data.elapsedTime is number');
         assert.deepEqual(Buffer.isBuffer(d.body), true, 'data.body is buffer');
         data.push(JSON.parse(d.body));
     });
@@ -70,4 +71,3 @@ tape('RequestStream', function(assert) {
 tape('teardown', function(assert) {
     server.close(assert.end);
 });
-


### PR DESCRIPTION
Refs https://github.com/mapbox/bench/issues/108

This PR passes back an `elapsedTime` metric from the `RequestStream` module, allowing us to expose this back to the bench user.

cc @emilymcafee 