### PR TITLE
aws-log-replay is an unstoppable force

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "rules": {
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "quote-props": [2, "as-needed"],
+    "no-console": [1],
+    "semi": [2, "always"],
+    "space-before-function-paren": [2, "never"],
+    "object-curly-spacing": [2, "always"],
+    "array-bracket-spacing": [2, "never"],
+    "comma-spacing": [2, { "before": false, "after": true }],
+    "key-spacing": [2, { "beforeColon": false, "afterColon": true }]
+  },
+  "env": {
+      "node": true,
+      "es6": true
+  },
+  "globals": {
+      "process": true,
+      "module": true,
+      "require": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
 var request = require('requestretry');
-var s3scan = require('s3scan');
-var split = require('split');
-var zlib = require('zlib');
 var url = require('url');
 var stream = require('stream');
-var queue = require('queue-async');
 var crypto = require('crypto');
 var parallel = require('parallel-stream');
 
@@ -19,14 +15,14 @@ module.exports.SampleStream = SampleStream;
  * @param {string path} - a cloudfront path to decode
  */
 function cloudFrontDecode(path) {
-    var whitelist = ['3C', '3E', '22', '23', '25', '7B', '7D', '7C', '5C', '5E', '7E', '5B', '5D', '60', '27', '20'];
-    return path.replace(/%([\dA-F]{2})/g, function(match, hex) {
-        var code = parseInt(hex, 16);
-        if ((code < 32) || (code > 127) || (whitelist.indexOf(hex) !== -1))
-            return String.fromCharCode(code);
-        else
+  var whitelist = ['3C', '3E', '22', '23', '25', '7B', '7D', '7C', '5C', '5E', '7E', '5B', '5D', '60', '27', '20'];
+  return path.replace(/%([\dA-F]{2})/g, function(match, hex) {
+    var code = parseInt(hex, 16);
+    if ((code < 32) || (code > 127) || (whitelist.indexOf(hex) !== -1))
+      return String.fromCharCode(code);
+    else
             return match;
-    });
+  });
 }
 
 /**
@@ -35,31 +31,31 @@ function cloudFrontDecode(path) {
  * @param {string} type
  */
 function GeneratePath(type) {
-    var generatePath = new stream.Transform({ objectMode: true });
-    generatePath._transform = function(line, enc, callback) {
-        if (!line) return callback();
-        if (Buffer.isBuffer(line)) line = line.toString('utf-8');
-        if (type.toLowerCase() == 'cloudfront') {
-            var parts = line.split(/\s+/g);
-            if (parts.length > 7) {
-                if (parts[11] && parts[11] !== "-") {
-                    generatePath.push(cloudFrontDecode(parts[7] + "?" + parts[11]));
-                } else {
-                    generatePath.push(cloudFrontDecode(parts[7]));
-                }
-            }
-        } else if (type.toLowerCase() == 'lb') {
-            if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
-            var parts = line.split(/\s+/g);
-            if (parts.length < 12) return callback();
-            var path = parts.length === 18 ? parts[12] : parts[13];
-            path = path.split(/:[0-9]\w+/g)[1];
-            if (!path) return callback();
-            generatePath.push(path);
+  var generatePath = new stream.Transform({ objectMode: true });
+  generatePath._transform = function(line, enc, callback) {
+    if (!line) return callback();
+    if (Buffer.isBuffer(line)) line = line.toString('utf-8');
+    if (type.toLowerCase() == 'cloudfront') {
+      var parts = line.split(/\s+/g);
+      if (parts.length > 7) {
+        if (parts[11] && parts[11] !== '-') {
+          generatePath.push(cloudFrontDecode(parts[7] + '?' + parts[11]));
+        } else {
+          generatePath.push(cloudFrontDecode(parts[7]));
         }
-        callback();
-    };
-    return generatePath;
+      }
+    } else if (type.toLowerCase() == 'lb') {
+      if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
+      parts = line.split(/\s+/g);
+      if (parts.length < 12) return callback();
+      var path = parts.length === 18 ? parts[12] : parts[13];
+      path = path.split(/:[0-9]\w+/g)[1];
+      if (!path) return callback();
+      generatePath.push(path);
+    }
+    callback();
+  };
+  return generatePath;
 }
 
 /**
@@ -69,30 +65,30 @@ function GeneratePath(type) {
  * @param {string} options.baseurl - Required. An http or https url prepended to paths when making requests.
  */
 function RequestStream(options) {
-    options = options || {};
-    if (!options.baseurl) throw new Error('options.baseurl should be an http:// or https:// baseurl for replay requests');
-    if (!options.hwm) options.hwm = 100;
+  options = options || {};
+  if (!options.baseurl) throw new Error('options.baseurl should be an http:// or https:// baseurl for replay requests');
+  if (!options.hwm) options.hwm = 100;
 
-    function transform(pathname, enc, callback) {
-        if (typeof pathname !== 'string') pathname = pathname.toString('utf8');
-        if (!pathname || pathname.indexOf('/') !== 0) return callback();
+  function transform(pathname, enc, callback) {
+    if (typeof pathname !== 'string') pathname = pathname.toString('utf8');
+    if (!pathname || pathname.indexOf('/') !== 0) return callback();
 
-        var uri = url.parse(pathname, true);
-        var requrl = options.baseurl + url.format(uri);
+    var uri = url.parse(pathname, true);
+    var requrl = options.baseurl + url.format(uri);
 
-        request({
-            agent: options.agent,
-            encoding: null,
-            uri: requrl
-        }, (err, res, body) => {
-            if (err) return callback(err);
-            if (res.statusCode !== 200) return callback();
-            this.push({ url: requrl, body: body });
-            callback();
-        });
-    }
+    request({
+      agent: options.agent,
+      encoding: null,
+      uri: requrl
+    }, (err, res, body) => {
+      if (err) return callback(err);
+      if (res.statusCode !== 200) return callback();
+      this.push({ url: requrl, body: body });
+      callback();
+    });
+  }
 
-    return parallel.transform(transform, { concurrency: options.hwm, objectMode: true });
+  return parallel.transform(transform, { concurrency: options.hwm, objectMode: true });
 }
 
 /**
@@ -104,27 +100,27 @@ function RequestStream(options) {
  * @param {string} options.filter - Optional. Regex pre-filter applied to input.
  */
 function SampleStream(options) {
-    options = options || {};
-    if (!options.rate) throw new Error('must specify a sample rate (0 < sample < 1)');
-    if ((parseFloat(options.rate) <= 0) || (parseFloat(options.rate) >= 1)) throw new Error('rate must be between 0 and 1');
+  options = options || {};
+  if (!options.rate) throw new Error('must specify a sample rate (0 < sample < 1)');
+  if ((parseFloat(options.rate) <= 0) || (parseFloat(options.rate) >= 1)) throw new Error('rate must be between 0 and 1');
 
-    var sampleStream = new stream.Transform({ objectMode: true });
-    sampleStream.count = 0;
-    sampleStream.threshold = Math.round(parseFloat(options.rate) * Math.pow(2, 16));
-    if (options.filter) sampleStream.filter = new RegExp(options.filter);
-    sampleStream._transform = function(line, enc, callback) {
-        if (!line) return callback();
+  var sampleStream = new stream.Transform({ objectMode: true });
+  sampleStream.count = 0;
+  sampleStream.threshold = Math.round(parseFloat(options.rate) * Math.pow(2, 16));
+  if (options.filter) sampleStream.filter = new RegExp(options.filter);
+  sampleStream._transform = function(line, enc, callback) {
+    if (!line) return callback();
 
-        if ((sampleStream.filter) && (!sampleStream.filter.test(line)))
-            return callback();
+    if ((sampleStream.filter) && (!sampleStream.filter.test(line)))
+      return callback();
 
-        var hash = crypto.createHash('md5').update('cloudfront-log-read-salt-' + sampleStream.count).digest().readUInt16LE(0);
-        if (hash < sampleStream.threshold)
-            sampleStream.push(line);
-        sampleStream.count++;
+    var hash = crypto.createHash('md5').update('cloudfront-log-read-salt-' + sampleStream.count).digest().readUInt16LE(0);
+    if (hash < sampleStream.threshold)
+      sampleStream.push(line);
+    sampleStream.count++;
 
-        callback();
-    };
+    callback();
+  };
 
-    return sampleStream;
+  return sampleStream;
 }

--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ function RequestStream(options) {
   if (!options.hwm) options.hwm = 100;
 
   function transform(pathname, enc, callback) {
+    if (this._closed) return setImmediate(callback);
+    
     if (typeof pathname !== 'string') pathname = pathname.toString('utf8');
     if (!pathname || pathname.indexOf('/') !== 0) return callback();
 
@@ -88,7 +90,12 @@ function RequestStream(options) {
     });
   }
 
-  return parallel.transform(transform, { concurrency: options.hwm, objectMode: true });
+  var requestStream = parallel.transform(transform, { concurrency: options.hwm, objectMode: true });
+  requestStream.close = function() {
+    requestStream._closed = true;
+  };
+
+  return requestStream;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "agentkeepalive": "^2.2.0",
     "aws-sdk-mock": "^1.4.1",
     "minimist": "^1.2.0",
+    "parallel-stream": "^1.1.2",
     "queue-async": "1.0.x",
     "requestretry": "1.5.x",
     "s3scan": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "documentation": "2.0.x",
+    "eslint": "^3.11.1",
     "tape": "3.5.x"
   },
   "bin": {
@@ -27,6 +28,7 @@
     "sample": "./bin/sample"
   },
   "scripts": {
+    "pretest": "eslint test bin index.js",
     "test": "tape test/*.test.js"
   }
 }

--- a/test/GeneratePath.test.js
+++ b/test/GeneratePath.test.js
@@ -1,42 +1,41 @@
-var fs = require('fs');
 var reader = require('../index.js');
 var tape = require('tape');
 
 tape('GeneratePath [cloudfront]', function(assert) {
-    var data = [];
-    var generatePath = reader.GeneratePath('cloudfront');
-    generatePath.on('data', function(d) {
-        data.push(d);
-    });
-    generatePath.on('end', function() {
-        assert.equal(data[0], '/a.json?option=1');
-        assert.equal(data[1], '/geocoding/v5/mapbox.places/2401%20Gw%20Loy%20Rd%20New%20Market%2C%20Tn%2037820.json?access_token=pk.abc.123');
-        assert.equal(data.length, 2);
-        assert.end();
-    });
-    generatePath.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
-    generatePath.write('2016-04-14      02:40:16        DFW50   1771    108.223.176.206 GET     d3eju24r2ptc5d.cloudfront.net   /geocoding/v5/mapbox.places/2401%2520Gw%2520Loy%2520Rd%2520New%2520Market%252C%2520Tn%252037820.json        200     -       Mozilla/5.0%2520(iPhone;%2520CPU%2520iPhone%2520OS%25209_2%2520like%2520Mac%2520OS%2520X)%2520AppleWebKit/601.1.46%2520(KHTML,%2520like%2520Gecko)%2520Mobile/13C75 access_token=pk.abc.123       -       Miss    TbuZW6a2aUgeR9kBenr30jytUpJW5tSuv20Xv3n-smuTCqSdBjGpZQ==    a.tiles.mapbox.com      http    451     1.954   -       -       -       Miss\n');
-    generatePath.write('\n');
-    generatePath.end();
+  var data = [];
+  var generatePath = reader.GeneratePath('cloudfront');
+  generatePath.on('data', function(d) {
+    data.push(d);
+  });
+  generatePath.on('end', function() {
+    assert.equal(data[0], '/a.json?option=1');
+    assert.equal(data[1], '/geocoding/v5/mapbox.places/2401%20Gw%20Loy%20Rd%20New%20Market%2C%20Tn%2037820.json?access_token=pk.abc.123');
+    assert.equal(data.length, 2);
+    assert.end();
+  });
+  generatePath.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
+  generatePath.write('2016-04-14      02:40:16        DFW50   1771    108.223.176.206 GET     d3eju24r2ptc5d.cloudfront.net   /geocoding/v5/mapbox.places/2401%2520Gw%2520Loy%2520Rd%2520New%2520Market%252C%2520Tn%252037820.json        200     -       Mozilla/5.0%2520(iPhone;%2520CPU%2520iPhone%2520OS%25209_2%2520like%2520Mac%2520OS%2520X)%2520AppleWebKit/601.1.46%2520(KHTML,%2520like%2520Gecko)%2520Mobile/13C75 access_token=pk.abc.123       -       Miss    TbuZW6a2aUgeR9kBenr30jytUpJW5tSuv20Xv3n-smuTCqSdBjGpZQ==    a.tiles.mapbox.com      http    451     1.954   -       -       -       Miss\n');
+  generatePath.write('\n');
+  generatePath.end();
 });
 
 tape('GeneratePath [elb]', function(assert) {
-    var data = [];
-    var generatePath = reader.GeneratePath('lb');
-    generatePath.on('data', function(d) {
-        data.push(d);
-    });
-    generatePath.on('end', function() {
-        assert.equal(data[0], '/a.json?option=1');
-        assert.equal(data[1], '/b.json?option=1&other=2');
-        assert.equal(data[2], '/ham/sam?iam');
-        assert.equal(data.length, 3);
-        assert.end();
-    });
-    generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -');
-    generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 200 200 0 0 "GET http://green-eggs.com:666/b.json?option=1&other=2 HTTP/1.1" "Amazon CloudFront" - -');
-    generatePath.write('us-east-1.elb.amazonaws.com:666/ HTTP/1.1" "Amazon Route 53 Health Check Service; ref:000-000-0000; report http://green.eggs" ABCD-EFGH TLSv1.2');
-    generatePath.write('https 2016-09-25T07:15:01.253924Z app/api-green-eggs/1234 00.000.000.00:00000 00.0.0.000:00000 0.000 0.000 0.000 000 000 0000 000 "POST https://green.eggs.com:000/ham/sam?iam HTTP/1.1" "(null)/0.0.0/000 greeneggsandham/0.0" ABCDE-ABC-ABC000-ABC TLSv1 greeneggsandhamsamiam');
-    generatePath.write('\n');
-    generatePath.end();
+  var data = [];
+  var generatePath = reader.GeneratePath('lb');
+  generatePath.on('data', function(d) {
+    data.push(d);
+  });
+  generatePath.on('end', function() {
+    assert.equal(data[0], '/a.json?option=1');
+    assert.equal(data[1], '/b.json?option=1&other=2');
+    assert.equal(data[2], '/ham/sam?iam');
+    assert.equal(data.length, 3);
+    assert.end();
+  });
+  generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -');
+  generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 200 200 0 0 "GET http://green-eggs.com:666/b.json?option=1&other=2 HTTP/1.1" "Amazon CloudFront" - -');
+  generatePath.write('us-east-1.elb.amazonaws.com:666/ HTTP/1.1" "Amazon Route 53 Health Check Service; ref:000-000-0000; report http://green.eggs" ABCD-EFGH TLSv1.2');
+  generatePath.write('https 2016-09-25T07:15:01.253924Z app/api-green-eggs/1234 00.000.000.00:00000 00.0.0.000:00000 0.000 0.000 0.000 000 000 0000 000 "POST https://green.eggs.com:000/ham/sam?iam HTTP/1.1" "(null)/0.0.0/000 greeneggsandham/0.0" ABCDE-ABC-ABC000-ABC TLSv1 greeneggsandhamsamiam');
+  generatePath.write('\n');
+  generatePath.end();
 });

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var reader = require('../index.js');
 var tape = require('tape');
 var http = require('http');
@@ -6,68 +5,67 @@ var server;
 var count = 0;
 
 tape('setup', function(assert) {
-    server = http.createServer(function(req, res) {
-        count++;
-        if (/\/c\.json/.test(req.url)) {
-            res.writeHead(404);
-        } else {
-            res.writeHead(200);
-            res.write(JSON.stringify({ obj: req.url.split('/')[1].split('.')[0] }));
-        }
-        setTimeout(function() {
-            res.end();
-        }, 1000);
-    });
-    server.listen(9999, assert.end);
+  server = http.createServer(function(req, res) {
+    count++;
+    if (/\/c\.json/.test(req.url)) {
+      res.writeHead(404);
+    } else {
+      res.writeHead(200);
+      res.write(JSON.stringify({ obj: req.url.split('/')[1].split('.')[0] }));
+    }
+    setTimeout(function() {
+      res.end();
+    }, 1000);
+  });
+  server.listen(9999, assert.end);
 });
 
 tape('RequestStream [concurrency]', function(assert) {
-    var reqstream = reader.RequestStream({
-        baseurl: 'http://localhost:9999',
-        hwm: 3
-    });
-    reqstream.on('data', function(d) { 
-    });
-    reqstream.on('end', function() { 
-        assert.end();
-    });
-    var req = 0;
-    var j = setInterval(function() {
-        req = req + 3;
-        assert.equal(req, count);
-    }, 1000);
-    for (var i = 0; i < 10; i++) {
-        reqstream.write('/a.json?option=1\n');
-    }
-    setTimeout(function() {
-        clearInterval(j);
-        reqstream.end();
-    }, 3500);
+  var reqstream = reader.RequestStream({
+    baseurl: 'http://localhost:9999',
+    hwm: 3
+  });
+  reqstream.on('data', function() {
+  });
+  reqstream.on('end', function() {
+    assert.end();
+  });
+  var req = 0;
+  var j = setInterval(function() {
+    req = req + 3;
+    assert.equal(req, count);
+  }, 1000);
+  for (var i = 0; i < 10; i++) {
+    reqstream.write('/a.json?option=1\n');
+  }
+  setTimeout(function() {
+    clearInterval(j);
+    reqstream.end();
+  }, 3500);
 });
 
 tape('RequestStream', function(assert) {
-    var data = [];
-    var reqstream = reader.RequestStream({
-        baseurl: 'http://localhost:9999'
-    });
-    reqstream.on('data', function(d) {
-        assert.deepEqual(/http:\/\/localhost:9999\/(a|b)\.json/.test(d.url), true, 'data.url is object url');
-        assert.deepEqual(Buffer.isBuffer(d.body), true, 'data.body is buffer');
-        data.push(JSON.parse(d.body));
-    });
-    reqstream.on('end', function() {
-        assert.deepEqual(data.length, 2, 'emits 2 objects');
-        assert.deepEqual(data.map(function(d) { return d.obj }).sort(), ['a', 'b'], 'emits objects a, b');
-        assert.end();
-    });
-    reqstream.write('/a.json?option=1\n');
-    reqstream.write('/b.json?option=2\n');
-    reqstream.write('/c.json?option=2\n');
-    reqstream.write('\n');
-    reqstream.end();
+  var data = [];
+  var reqstream = reader.RequestStream({
+    baseurl: 'http://localhost:9999'
+  });
+  reqstream.on('data', function(d) {
+    assert.deepEqual(/http:\/\/localhost:9999\/(a|b)\.json/.test(d.url), true, 'data.url is object url');
+    assert.deepEqual(Buffer.isBuffer(d.body), true, 'data.body is buffer');
+    data.push(JSON.parse(d.body));
+  });
+  reqstream.on('end', function() {
+    assert.deepEqual(data.length, 2, 'emits 2 objects');
+    assert.deepEqual(data.map(function(d) { return d.obj; }).sort(), ['a', 'b'], 'emits objects a, b');
+    assert.end();
+  });
+  reqstream.write('/a.json?option=1\n');
+  reqstream.write('/b.json?option=2\n');
+  reqstream.write('/c.json?option=2\n');
+  reqstream.write('\n');
+  reqstream.end();
 });
 
 tape('teardown', function(assert) {
-    server.close(assert.end);
+  server.close(assert.end);
 });
-

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -17,6 +17,7 @@ tape('setup', function(assert) {
       res.end();
     }, 1000);
   });
+  server.reset = function() { count = 0; };
   server.listen(9999, assert.end);
 });
 
@@ -59,6 +60,27 @@ tape('RequestStream', function(assert) {
     assert.deepEqual(data.map(function(d) { return d.obj; }).sort(), ['a', 'b'], 'emits objects a, b');
     assert.end();
   });
+  reqstream.write('/a.json?option=1\n');
+  reqstream.write('/b.json?option=2\n');
+  reqstream.write('/c.json?option=2\n');
+  reqstream.write('\n');
+  reqstream.end();
+});
+
+tape('RequestStream close', function(assert) {
+  server.reset();
+  var reqstream = reader.RequestStream({
+    baseurl: 'http://localhost:8888' // all requests ought to fail
+  });
+
+  reqstream.on('error', function(err) { assert.ifError(err, 'should not fail'); });
+  reqstream.on('finish', function() {
+    assert.equal(count, 0, 'no requests were made');
+    assert.end();
+  });
+
+  reqstream.close();
+  assert.ok(reqstream._closed, 'marked stream as closed');
   reqstream.write('/a.json?option=1\n');
   reqstream.write('/b.json?option=2\n');
   reqstream.write('/c.json?option=2\n');

--- a/test/SampleStream.test.js
+++ b/test/SampleStream.test.js
@@ -5,34 +5,33 @@ var split = require('split');
 var path = require('path');
 
 function testFunc(r, f, expected, t) {
-    var sample = reader.SampleStream({rate: (r * 0.1), filter: f});
+  var sample = reader.SampleStream({ rate: (r * 0.1), filter: f });
 
-    var splitStream = split();
-    var sampledStream = splitStream.pipe(sample);
+  var splitStream = split();
+  splitStream.pipe(sample);
 
-    var count = 0;
-    sample.on('data', function (data) {
-        count++;
-    });
-    sample.on('finish', function () {
-        t.equals(count, expected, 'got expected records (' + expected + ')');
-        t.end();
-    });
+  var count = 0;
+  sample.on('data', function() {
+    count++;
+  });
+  sample.on('finish', function() {
+    t.equals(count, expected, 'got expected records (' + expected + ')');
+    t.end();
+  });
 
-    for (var k = 0; k < 1000; k++) {
+  for (var k = 0; k < 1000; k++) {
         // each of these is 9 records long
-        splitStream.write(fs.readFileSync(path.join(__dirname + '/fixtures/AAAAAAAAAAAAAA.2015-10-19-17.e5b6526a'), 'utf8'));
-    }
-    splitStream.end();
+    splitStream.write(fs.readFileSync(path.join(__dirname + '/fixtures/AAAAAAAAAAAAAA.2015-10-19-17.e5b6526a'), 'utf8'));
+  }
+  splitStream.end();
 }
 
 var expectedUnfiltered = [949, 1879, 2820, 3728, 4592, 5449, 6323, 7220, 8136];
 for (var rate = 1; rate < 10; rate++) {
-    tape('unfiltered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, false, expectedUnfiltered[rate - 1]));
+  tape('unfiltered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, false, expectedUnfiltered[rate - 1]));
 }
 
 var expectedFiltered = [299, 607, 904, 1218, 1509, 1788, 2085, 2384, 2716];
-for (var rate = 1; rate < 10; rate++) {
-    tape('filtered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, 'a\.json', expectedFiltered[rate - 1]));
+for (rate = 1; rate < 10; rate++) {
+  tape('filtered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, 'a\.json', expectedFiltered[rate - 1]));
 }
-

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -1,131 +1,128 @@
-var fs = require('fs');
 var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 var tape = require('tape');
-var queue = require('queue-async');
 var http = require('http');
 var server;
 
 tape('setup', function(assert) {
-    server = http.createServer(function(req, res) {
-        if (/\/c\.json/.test(req.url)) {
-            res.writeHead(404);
-        } else {
-            res.writeHead(200);
-            res.write(JSON.stringify({ obj: req.url.split('/')[1].split('.')[0] }));
-        }
-        res.end();
-    });
-    server.listen(9999, assert.end);
+  server = http.createServer(function(req, res) {
+    if (/\/c\.json/.test(req.url)) {
+      res.writeHead(404);
+    } else {
+      res.writeHead(200);
+      res.write(JSON.stringify({ obj: req.url.split('/')[1].split('.')[0] }));
+    }
+    res.end();
+  });
+  server.listen(9999, assert.end);
 });
 
 tape('pathreplay: usage', function(assert) {
-    exec(__dirname + '/../bin/pathreplay', {env:process.env}, function(err, stdout, stderr) {
-        assert.equal(err.code, 1, 'exits 1');
-        assert.equal(stderr, 'Usage: pathreplay <baseurl> [--concurrency=<n>]\n', 'shows usage');
-        assert.end();
-    });
+  exec(__dirname + '/../bin/pathreplay', { env: process.env }, function(err, stdout, stderr) {
+    assert.equal(err.code, 1, 'exits 1');
+    assert.equal(stderr, 'Usage: pathreplay <baseurl> [--concurrency=<n>]\n', 'shows usage');
+    assert.end();
+  });
 });
 
 tape('pathreplay', function(assert) {
-    var child = spawn(__dirname + '/../bin/pathreplay', ['http://localhost:9999']);
-    var data = [];
-    child.stdout.on('data', function(d) {
-        data.push(d.toString());
-    });
-    child.stderr.on('data', function(data) {
-        assert.ifError(data);
-    });
-    child.on('close', function(code) {
-        assert.deepEqual(data, ['{"obj":"a"}\n', '{"obj":"b"}\n'], 'emits obj a, b');
-        assert.equal(code, 0, 'exits 0');
-        assert.end();
-    });
-    child.stdin.write('/a.json\n');
-    child.stdin.write('/b.json\n');
-    child.stdin.write('/c.json\n');
-    child.stdin.write('\n');
-    child.stdin.end();
+  var child = spawn(__dirname + '/../bin/pathreplay', ['http://localhost:9999']);
+  var data = [];
+  child.stdout.on('data', function(d) {
+    data.push(d.toString());
+  });
+  child.stderr.on('data', function(data) {
+    assert.ifError(data);
+  });
+  child.on('close', function(code) {
+    assert.deepEqual(data, ['{"obj":"a"}\n', '{"obj":"b"}\n'], 'emits obj a, b');
+    assert.equal(code, 0, 'exits 0');
+    assert.end();
+  });
+  child.stdin.write('/a.json\n');
+  child.stdin.write('/b.json\n');
+  child.stdin.write('/c.json\n');
+  child.stdin.write('\n');
+  child.stdin.end();
 });
 
 tape('pathreplay [bad args]', function(assert) {
-    var child = spawn(__dirname + '/../bin/pathreplay', ['foobar', 'http://localhost:9999']);
-    var data = [];
-    child.stderr.on('data', function(data) {
-        assert.equal(data.toString(), 'Usage: pathreplay <baseurl> [--concurrency=<n>]\n', 'Usage when args out of order');
-        assert.end();
-    });
+  var child = spawn(__dirname + '/../bin/pathreplay', ['foobar', 'http://localhost:9999']);
+  child.stderr.on('data', function(data) {
+    assert.equal(data.toString(), 'Usage: pathreplay <baseurl> [--concurrency=<n>]\n', 'Usage when args out of order');
+    assert.end();
+  });
 });
 
 tape('pathreplay [concurrency arg]', function(assert) {
-    var child = spawn(__dirname + '/../bin/pathreplay', ['http://localhost:9999', '--concurrency=5']);
-    var data = [];
-    child.stdout.on('data', function(d) {
-        data.push(d.toString());
-    });
-    child.stderr.on('data', function(data) {
-        assert.ifError(data);
-    });
-    child.on('close', function(code) {
-        assert.deepEqual(data, ['{"obj":"a"}\n'], 'emits obj a');
-        assert.equal(code, 0, 'exits 0');
-        assert.end();
-    });
-    child.stdin.write('/a.json\n');
-    child.stdin.write('\n');
-    child.stdin.end();
+  var child = spawn(__dirname + '/../bin/pathreplay', ['http://localhost:9999', '--concurrency=5']);
+  var data = [];
+  child.stdout.on('data', function(d) {
+    data.push(d.toString());
+  });
+  child.stderr.on('data', function(data) {
+    assert.ifError(data);
+  });
+  child.on('close', function(code) {
+    assert.deepEqual(data, ['{"obj":"a"}\n'], 'emits obj a');
+    assert.equal(code, 0, 'exits 0');
+    assert.end();
+  });
+  child.stdin.write('/a.json\n');
+  child.stdin.write('\n');
+  child.stdin.end();
 });
 
 tape('teardown', function(assert) {
-    server.close(assert.end);
+  server.close(assert.end);
 });
 
 tape('generatepath: usage', function(assert) {
-    exec(__dirname + '/../bin/generatepath', {env:process.env}, function(err, stdout, stderr) {
-        assert.equal(err.code, 1, 'exits 1');
-        assert.equal(stderr, 'Usage: generatepath <type>\n<type> can be "cloudfront" or "lb"\n', 'shows usage');
-        assert.end();
-    });
+  exec(__dirname + '/../bin/generatepath', { env: process.env }, function(err, stdout, stderr) {
+    assert.equal(err.code, 1, 'exits 1');
+    assert.equal(stderr, 'Usage: generatepath <type>\n<type> can be "cloudfront" or "lb"\n', 'shows usage');
+    assert.end();
+  });
 });
 
 tape('generatepath [cloudfront]', function(assert) {
-    var child = spawn(__dirname + '/../bin/generatepath', ['cloudfront']);
-    var data = [];
-    child.stdout.on('data', function(d) {
-        data.push(d.toString());
-    });
-    child.stderr.on('data', function(data) {
-        assert.ifError(data);
-    });
-    child.on('close', function(code) {
-        assert.equal(data[0], '/a.json?option=1\n');
-        assert.equal(data[1], '/b.json?option=2\n');
-        assert.equal(data[2], '/c.json?option=2\n');
-        assert.equal(code, 0, 'exits 0');
-        assert.end();
-    });
-    child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
-    child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/b.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
-    child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/c.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
-    child.stdin.write('\n');
-    child.stdin.end();
+  var child = spawn(__dirname + '/../bin/generatepath', ['cloudfront']);
+  var data = [];
+  child.stdout.on('data', function(d) {
+    data.push(d.toString());
+  });
+  child.stderr.on('data', function(data) {
+    assert.ifError(data);
+  });
+  child.on('close', function(code) {
+    assert.equal(data[0], '/a.json?option=1\n');
+    assert.equal(data[1], '/b.json?option=2\n');
+    assert.equal(data[2], '/c.json?option=2\n');
+    assert.equal(code, 0, 'exits 0');
+    assert.end();
+  });
+  child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
+  child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/b.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
+  child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/c.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
+  child.stdin.write('\n');
+  child.stdin.end();
 });
 
 tape('generatepath [lb]', function(assert) {
-    var child = spawn(__dirname + '/../bin/generatepath', ['lb']);
-    var data = [];
-    child.stdout.on('data', function(d) {
-        data.push(d.toString());
-    });
-    child.stderr.on('data', function(data) {
-        assert.ifError(data);
-    });
-    child.on('close', function(code) {
-        assert.equal(data[0], '/a.json?option=1\n');
-        assert.equal(code, 0, 'exits 0');
-        assert.end();
-    });
-    child.stdin.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -\n');
-    child.stdin.write('\n');
-    child.stdin.end();
+  var child = spawn(__dirname + '/../bin/generatepath', ['lb']);
+  var data = [];
+  child.stdout.on('data', function(d) {
+    data.push(d.toString());
+  });
+  child.stderr.on('data', function(data) {
+    assert.ifError(data);
+  });
+  child.on('close', function(code) {
+    assert.equal(data[0], '/a.json?option=1\n');
+    assert.equal(code, 0, 'exits 0');
+    assert.end();
+  });
+  child.stdin.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -\n');
+  child.stdin.write('\n');
+  child.stdin.end();
 });


### PR DESCRIPTION
- replaced old-school parallel stream logic with https://github.com/rclark/parallel-stream
- hit with the eslint stick
- added a `.close()` method to the request stream. Once this function is called, subsequent invocations of the transform function will no-op. The hope is that this will push us through the backlogged requests-to-be-made and complete the stream quickly.