### PR TITLE
RequestStream strictSSL option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,10 @@
+# Change Log
+All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
+
+## Unreleased
+- RequestStream strictSSL option to optionally disable SSL cert checking
+
+--
+
+## 2.3.1 2016-12-08
+- Last release without a changelog

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ function GeneratePath(type) {
  * host. LH side expects a line-oriented stream of paths (& querystrings).
  * @param {object} options
  * @param {string} options.baseurl - Required. An http or https url prepended to paths when making requests.
+ * @param {string} options.strictSSL - Optional. If true (default), requires SSL/TLS certificates to be valid
  */
 function RequestStream(options) {
   options = options || {};
@@ -80,6 +81,7 @@ function RequestStream(options) {
 
     request({
       agent: options.agent,
+      strictSSL: options.strictSSL === false ? false : true,
       encoding: null,
       uri: requrl,
       time: true


### PR DESCRIPTION
Making it possible to disable SSL certificate checks.