### PR TITLE
RequestStream return all status codes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## Unreleased
 - RequestStream strictSSL option to optionally disable SSL cert checking
+- RequestStream return all HTTP status codes
 
 --
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ function RequestStream(options) {
       time: true
     }, (err, res, body) => {
       if (err) return callback(err);
-      if (res.statusCode !== 200) return callback();
       this.push({ url: requrl, elapsedTime: res.elapsedTime, statusCode: res.statusCode, body: body });
       callback();
     });

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -51,11 +51,21 @@ tape('RequestStream', function(assert) {
     baseurl: 'http://localhost:9999'
   });
   reqstream.on('data', function(d) {
-    assert.deepEqual(/http:\/\/localhost:9999\/(a|b)\.json/.test(d.url), true, 'data.url is object url');
-    assert.deepEqual(!isNaN(d.elapsedTime), true, 'data.elapsedTime is a number');
-    assert.deepEqual(!isNaN(d.statusCode), true, 'data.statusCode is a number');
+    switch (d.statusCode) {
+    case 200:
+      assert.deepEqual(/http:\/\/localhost:9999\/(a|b)\.json/.test(d.url), true, 'data.url is object url');
+      data.push(JSON.parse(d.body));
+      break;
+    case 404:
+      assert.deepEqual(/http:\/\/localhost:9999\/c\.json/.test(d.url), true, 'data.url is object url');
+      break;
+    default:
+      assert.fail('Invalid statusCode ' + d.statusCode);
+      return;
+    }
+
     assert.deepEqual(Buffer.isBuffer(d.body), true, 'data.body is buffer');
-    data.push(JSON.parse(d.body));
+    assert.deepEqual(!isNaN(d.elapsedTime), true, 'data.elapsedTime is a number');
   });
   reqstream.on('end', function() {
     assert.deepEqual(data.length, 2, 'emits 2 objects');

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -29,7 +29,9 @@ tape('pathreplay', function(assert) {
   var child = spawn(__dirname + '/../bin/pathreplay', ['http://localhost:9999']);
   var data = [];
   child.stdout.on('data', function(d) {
-    data.push(d.toString());
+    if (d.toString() != '\n') {
+      data.push(d.toString());
+    }
   });
   child.stderr.on('data', function(data) {
     assert.ifError(data);


### PR DESCRIPTION
Not sure why this was limited to `200` status codes only, since that hides potential problems when running a benchmark (e.g. 404s or 500).

/cc @emilymcafee @rclark @yhahn