### PR TITLE
emitted errors on bad log files

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function GeneratePath(type) {
       parts = line.split(/\s+/g);
       if (parts.length < 12) return callback();
       var path = parts.length === 18 ? parts[12] : parts[13];
+      if (path === undefined) return callback(new Error('Faild to parse log file'));
       path = path.split(/:[0-9]\w+/g)[1];
       if (!path) return callback();
       generatePath.push(path);


### PR DESCRIPTION
I just ran into a use case where I was passing it the wrong kind of log file and `aws-log-reply` was throwing an error in the GeneratePath transform. I think the right thing to do in this case is to emit an error. If that sounds right, I can update this PR to include tests.