### PR TITLE
Include timestamp in path split

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. For change 
 
 --
 
+## 2.4.1 2018-01-26
+
+- Allow timestamps in url paths
+
 ## 2.4.0 2017-02-23
 
 - RequestStream strictSSL option to optionally disable SSL cert checking

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function GeneratePath(type) {
       parts = line.split(/\s+/g);
       if (parts.length < 12) return callback();
       var path = parts.length === 18 ? parts[12] : parts[13];
-      path = path.split(/:[0-9]\w+/g)[1];
+      path = url.parse(path).path;
       if (!path) return callback();
       generatePath.push(path);
     }

--- a/test/GeneratePath.test.js
+++ b/test/GeneratePath.test.js
@@ -29,13 +29,15 @@ tape('GeneratePath [elb]', function(assert) {
     assert.equal(data[0], '/a.json?option=1');
     assert.equal(data[1], '/b.json?option=1&other=2');
     assert.equal(data[2], '/ham/sam?iam');
-    assert.equal(data.length, 3);
+    assert.equal(data[3], '/v1/thing/my.id?time=2017-05-31T22:05:32.562Z');
+    assert.equal(data.length, 4);
     assert.end();
   });
   generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -');
   generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 200 200 0 0 "GET http://green-eggs.com:666/b.json?option=1&other=2 HTTP/1.1" "Amazon CloudFront" - -');
   generatePath.write('us-east-1.elb.amazonaws.com:666/ HTTP/1.1" "Amazon Route 53 Health Check Service; ref:000-000-0000; report http://green.eggs" ABCD-EFGH TLSv1.2');
   generatePath.write('https 2016-09-25T07:15:01.253924Z app/api-green-eggs/1234 00.000.000.00:00000 00.0.0.000:00000 0.000 0.000 0.000 000 000 0000 000 "POST https://green.eggs.com:000/ham/sam?iam HTTP/1.1" "(null)/0.0.0/000 greeneggsandham/0.0" ABCDE-ABC-ABC000-ABC TLSv1 greeneggsandhamsamiam');
+  generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://api.example.com:80/v1/thing/my.id?time=2017-05-31T22:05:32.562Z HTTP/1.1" "Amazon CloudFront" - -');
   generatePath.write('\n');
   generatePath.end();
 });


### PR DESCRIPTION
Per https://github.com/mapbox/aws-log-replay/issues/41, allow for timestamps in url paths. Also, using `url` module is a bit more intuitive than regex.

cc @mapsam @jakepruitt @springmeyer 