### PR TITLE
Option to use referer in replayed requests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file. For change 
 
 --
 
+## 2.6.0 2020-08-13
+
+- Adds option to include referer in stream when generating a path
+- If referer header is passed in to RequestStream, will include referer in request
+
 ## 2.4.1 2018-01-26
 
 - Allow timestamps in url paths

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function GeneratePath(type, keepReferer = false) {
         var referer = parts[9];
       }
       if (path && referer) generatePath.push([path, referer]);
-      if (path) generatePath.push(path);
+      else if (path) generatePath.push(path);
     } else if (type.toLowerCase() == 'lb') {
       if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
       parts = line.split(/\s+/g);

--- a/index.js
+++ b/index.js
@@ -44,13 +44,13 @@ function GeneratePath(type, keepReferer = false) {
         } else {
           path = cloudFrontDecode(parts[7]);
         }
+        if (keepReferer && parts[9] && parts[9] !== '-') {
+          var referer = parts[9];
+        }
+        // get Referer
+        if (path && referer) generatePath.push([path, referer]);
+        else generatePath.push(path);
       } 
-      // get Referer
-      if (keepReferer && parts[9] && parts[9] !== '-') {
-        var referer = parts[9];
-      }
-      if (path && referer) generatePath.push([path, referer]);
-      else if (path) generatePath.push(path);
     } else if (type.toLowerCase() == 'lb') {
       if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
       parts = line.split(/\s+/g);

--- a/index.js
+++ b/index.js
@@ -35,25 +35,21 @@ function GeneratePath(type, keepReferer = false) {
   generatePath._transform = function(line, enc, callback) {
     if (!line) return callback();
     if (Buffer.isBuffer(line)) line = line.toString('utf-8');
-    var path;
     if (type.toLowerCase() == 'cloudfront') {
       var parts = line.split(/\s+/g);
       if (parts.length > 7) {
         if (parts[11] && parts[11] !== '-') {
-          path = cloudFrontDecode(parts[7] + '?' + parts[11]);
+          var path = cloudFrontDecode(parts[7] + '?' + parts[11]);
         } else {
           path = cloudFrontDecode(parts[7]);
         }
       } 
       // get Referer
-      if (parts[9] && parts[9] !== '-') {
+      if (keepReferer && parts[9] && parts[9] !== '-') {
         var referer = parts[9];
       }
-      if (keepReferer && referer) {
-        generatePath.push([path, referer]);
-      } else {
-        generatePath.push(path);
-      }
+      if (path && referer) generatePath.push([path, referer]);
+      if (path) generatePath.push(path);
     } else if (type.toLowerCase() == 'lb') {
       if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
       parts = line.split(/\s+/g);

--- a/index.js
+++ b/index.js
@@ -42,8 +42,10 @@ function GeneratePath(type) {
         if (parts[11] && parts[11] !== '-') {
           generatePath.push(cloudFrontDecode(parts[7] + '?' + parts[11]));
         } else {
-          generatePath.push(cloudFrontDecode(parts[7]));
-        }
+      // get Referer
+      if (parts[9] && parts[9] !== '-') {
+        var referer = parts[9];
+      }
       }
     } else if (type.toLowerCase() == 'lb') {
       if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
@@ -57,26 +59,6 @@ function GeneratePath(type) {
     callback();
   };
   return generatePath;
-}
-
-/**
- * Gets referer from cf logs
- * @param 
- */
-function GetReferer() {
-  var getReferer = new stream.Transform({ objectMode: true });
-  getReferer._transform = function(line, enc, callback) {
-    if (!line) return callback();
-    if (Buffer.isBuffer(line)) line = line.toString('utf-8');
-    var parts = line.split(/\s+/g);
-    if (!parts[9]) return callback();
-    var referer = parts[9];
-    if (referer === '-') return callback();
-    getReferer.push(referer);
-    console.log("REF", referer)
-    callback();
-  };
-  return getReferer;
 }
 
 /**
@@ -107,8 +89,7 @@ function RequestStream(options) {
       time: true
     };
 
-    if (options.referer) {
-      var referer = this._transformState.writeChunk;
+    if (referer) {
       requestOptions.headers = { referer: referer };
     }
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function cloudFrontDecode(path) {
  * Transform stream for converting a CF log line into a path and querystring.
  * Expects a line-oriented stream of CF log lines.
  * @param {string} type
+ * @param {boolean} keepReferer - set to true if using cloudfront logs and you want to include the referer in the request
  */
 function GeneratePath(type, keepReferer = false) {
   var generatePath = new stream.Transform({ objectMode: true });
@@ -70,7 +71,6 @@ function GeneratePath(type, keepReferer = false) {
  * @param {object} options
  * @param {string} options.baseurl - Required. An http or https url prepended to paths when making requests.
  * @param {string} options.strictSSL - Optional. If true (default), requires SSL/TLS certificates to be valid
- * @param {boolean} options.referer - Optional. If true, include referer from requests (cloudfront logs only)
  */
 function RequestStream(options) {
   options = options || {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log-replay",
-  "version": "2.5.0",
+  "version": "2.6.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log-replay",
-  "version": "2.6.0-dev",
+  "version": "2.6.0-dev1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "2.5.0",
+  "version": "2.6.0-dev",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "aws-sdk-mock": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "2.6.0-dev",
+  "version": "2.6.0-dev1",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "aws-sdk-mock": "^4.0.0",

--- a/test/GeneratePath.test.js
+++ b/test/GeneratePath.test.js
@@ -19,6 +19,25 @@ tape('GeneratePath [cloudfront]', function(assert) {
   generatePath.end();
 });
 
+tape('GeneratePath with referer [cloudfront]', function(assert) {
+  var data = [];
+  var keepReferer = true;
+  var generatePath = reader.GeneratePath('cloudfront', keepReferer);
+  generatePath.on('data', function(d) {
+    data.push(d);
+  });
+  generatePath.on('end', function() {
+    assert.deepEqual(data[0], ['/a.json?option=1', 'https://www.mapbox.com/']);
+    assert.equal(data[1], '/geocoding/v5/mapbox.places/2401%20Gw%20Loy%20Rd%20New%20Market%2C%20Tn%2037820.json?access_token=pk.abc.123');
+    assert.equal(data.length, 2);
+    assert.end();
+  });
+  generatePath.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
+  generatePath.write('2016-04-14      02:40:16        DFW50   1771    108.223.176.206 GET     d3eju24r2ptc5d.cloudfront.net   /geocoding/v5/mapbox.places/2401%2520Gw%2520Loy%2520Rd%2520New%2520Market%252C%2520Tn%252037820.json        200     -       Mozilla/5.0%2520(iPhone;%2520CPU%2520iPhone%2520OS%25209_2%2520like%2520Mac%2520OS%2520X)%2520AppleWebKit/601.1.46%2520(KHTML,%2520like%2520Gecko)%2520Mobile/13C75 access_token=pk.abc.123       -       Miss    TbuZW6a2aUgeR9kBenr30jytUpJW5tSuv20Xv3n-smuTCqSdBjGpZQ==    a.tiles.mapbox.com      http    451     1.954   -       -       -       Miss\n');
+  generatePath.write('\n');
+  generatePath.end();
+});
+
 tape('GeneratePath [elb]', function(assert) {
   var data = [];
   var generatePath = reader.GeneratePath('lb');


### PR DESCRIPTION
This allows you to grab the referer from cloudfront logs when using `GeneratePath` (will pass to stream as `[url, referer]`) and `RequestStream` will pass the referer header to the request if it exists. This should be backwards compatible.

### Summary of changes
- Adds option to `keepReferer` (defaults to `false`) for `GeneratePath`. This will only be used for parsing cloudfront logs.
  - if `keepReferer = true`, `GeneratePath` will return an object `[url, referer]`
  - if `keepReferer = false`, `GeneratPath` will return a string `url` (previous behavior)
- If `[url, referer]` is passed in as the `data` to RequestStream, the request will be replayed with the referer header
- Tests for included referer