### PR TITLE
SPLT-689 custom headers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,5 +20,8 @@
       "module": true,
       "require": true
   },
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
   "extends": "eslint:recommended"
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
-## 4.0.0 (Unreleased)
+## 4.1.0
+- Adds option to include given headers in requests
+
+## 4.0.0
 - Released under the `@mapbox/aws-log-replay` namespace.
 - Replace `requestretry` with `got` for the HTTP client [#57](https://github.com/mapbox/aws-log-replay/pull/57)
 - Test on Node 16 and 18

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ function RequestStream(options) {
 
     if(options.headers) {
       console.log(`Headers before merge ${gotOptions.headers}`);
+      console.log(`Should apply headers:  ${JSON.stringify(options.headers)}`);
       if (gotOptions.headers){
         gotOptions.heders = { ...gotOptions.headers, ...options.headers };
       }

--- a/index.js
+++ b/index.js
@@ -129,15 +129,7 @@ function RequestStream(options) {
     }
 
     if(options.headers) {
-      console.log(`Headers before merge ${gotOptions.headers}`);
-      console.log(`Should apply headers:  ${JSON.stringify(options.headers)}`);
-      if (gotOptions.headers){
-        gotOptions.headers = { ...gotOptions.headers, ...options.headers };
-      }
-      else{
-        gotOptions.headers = options.headers;
-      }
-      console.log(`Headers after merge ${gotOptions.headers}`);
+      gotOptions.headers = { ...gotOptions.headers, ...options.headers };
     }
 
     got(url, gotOptions)

--- a/index.js
+++ b/index.js
@@ -132,10 +132,10 @@ function RequestStream(options) {
       console.log(`Headers before merge ${gotOptions.headers}`);
       console.log(`Should apply headers:  ${JSON.stringify(options.headers)}`);
       if (gotOptions.headers){
-        gotOptions.heders = { ...gotOptions.headers, ...options.headers };
+        gotOptions.headers = { ...gotOptions.headers, ...options.headers };
       }
       else{
-        gotOptions.heders = options.headers;
+        gotOptions.headers = options.headers;
       }
       console.log(`Headers after merge ${gotOptions.headers}`);
     }

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ function GeneratePath(type, keepReferer = false) {
  * @param {object} options
  * @param {string} options.baseurl - Required. An http or https url prepended to paths when making requests.
  * @param {string} options.strictSSL - Optional. If true (default), requires SSL/TLS certificates to be valid
+ * @param {object} options.headers - Optional. Headers to applied to requests
  */
 function RequestStream(options) {
   options = options || {};
@@ -125,6 +126,10 @@ function RequestStream(options) {
 
     if (referer) {
       gotOptions.headers = { referer };
+    }
+
+    if(options.headers) {
+      gotOptions.heders = {...gotOptions.headers, ...options.headers}
     }
 
     got(url, gotOptions)

--- a/index.js
+++ b/index.js
@@ -130,7 +130,12 @@ function RequestStream(options) {
 
     if(options.headers) {
       console.log(`Headers before merge ${gotOptions.headers}`);
-      gotOptions.heders = { ...gotOptions.headers, ...options.headers };
+      if (gotOptions.headers){
+        gotOptions.heders = { ...gotOptions.headers, ...options.headers };
+      }
+      else{
+        gotOptions.heders = options.headers;
+      }
       console.log(`Headers after merge ${gotOptions.headers}`);
     }
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function RequestStream(options) {
     }
 
     if(options.headers) {
-      gotOptions.heders = {...gotOptions.headers, ...options.headers}
+      gotOptions.heders = { ...gotOptions.headers, ...options.headers };
     }
 
     got(url, gotOptions)

--- a/index.js
+++ b/index.js
@@ -129,7 +129,9 @@ function RequestStream(options) {
     }
 
     if(options.headers) {
+      console.log(`Headers before merge ${gotOptions.headers}`);
       gotOptions.heders = { ...gotOptions.headers, ...options.headers };
+      console.log(`Headers after merge ${gotOptions.headers}`);
     }
 
     got(url, gotOptions)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.1.0-dev.5",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.1.0-dev.5",
+      "version": "4.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.1.0-dev.3",
+  "version": "4.1.0-dev.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.1.0-dev.3",
+      "version": "4.1.0-dev.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.1.0-dev.4",
+  "version": "4.1.0-dev.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.1.0-dev.4",
+      "version": "4.1.0-dev.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.0.0",
+  "version": "4.1.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.0.0",
+      "version": "4.1.0-dev.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.1.0-dev.1",
+  "version": "4.1.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.1.0-dev.1",
+      "version": "4.1.0-dev.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/aws-log-replay",
-  "version": "4.1.0-dev.2",
+  "version": "4.1.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/aws-log-replay",
-      "version": "4.1.0-dev.2",
+      "version": "4.1.0-dev.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "agentkeepalive": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.1.0-dev.1",
+  "version": "4.1.0-dev.2",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.1.0-dev.5",
+  "version": "4.1.0",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.0.0",
+  "version": "4.1.0-dev.1",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.1.0-dev.3",
+  "version": "4.1.0-dev.4",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.1.0-dev.2",
+  "version": "4.1.0-dev.3",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "@mapbox/aws-log-replay",
   "license": "BSD-2-Clause",
   "author": "Mapbox",
-  "version": "4.1.0-dev.4",
+  "version": "4.1.0-dev.5",
   "dependencies": {
     "agentkeepalive": "^3.5.1",
     "got": "^11.8.6",


### PR DESCRIPTION
**Relevant Tickets**: 
Part of https://mapbox.atlassian.net/browse/SPLT-689

## Summary of Changes

- Adds option to include given headers in requests. This is useful e.g. when replaying logs on an ELB which has [requiredHeaders](https://github.com/mapbox/ecs-api/blob/main/readme.md#limiting-access-to-elbs-with-custom-headers) implemented.

## Testing Strategy

Tested with [wiretap](https://github.com/mapbox/wiretap/pull/39)